### PR TITLE
Automatic ramp up 추가

### DIFF
--- a/experimenter/forms.py
+++ b/experimenter/forms.py
@@ -1,5 +1,7 @@
 ### html form을 정의하는 파일
 from django import forms
+from django.core.exceptions import ValidationError
+from django.utils.translation import gettext_lazy as _
 from .models import Experiment, Group
 
 class TextWithHoursWidget(forms.TextInput):
@@ -32,3 +34,12 @@ class GroupAdminForm(forms.ModelForm):
             'ramp_up_percent': TextWithPercentWidget,
         }
 
+    def clean(self):
+        cleaned_data = super().clean() # 기존의 clean()을 거친 데이터 받기
+        experiment = cleaned_data['experiment'] # 외래키로 참조하는 Experiment 인스턴스
+
+        # automatic ramp up을 사용할 때 ramp up 종료시간이 실험 시작시간과 종료시간 사이에 있지 않을 경우
+        if self.cleaned_data['ramp_up'] == 'automatic' and not \
+                (experiment.start_time < cleaned_data['ramp_up_end_time'] < experiment.end_time):
+            raise ValidationError(_("Ramp up end time must be between start time and end time of the experiment!"),
+                                      code='ramp_up_end_time_not_valid')

--- a/experimenter/managers.py
+++ b/experimenter/managers.py
@@ -27,6 +27,7 @@ class ExperimentManager(models.Manager):
         for i in range(num):
             self.create(name=str(i), algorithm=algorithm, assignment_update_interval=assignment_update_interval)
 
+    # 생성한 실험의 bandigt 활성화. Test 시에만 사용할 것.
     def activate_test_bandits(self):
         from .models import Experiment
         for experiment in Experiment.objects.all():
@@ -36,13 +37,15 @@ class ExperimentManager(models.Manager):
 class GroupManager(models.Manager):
 
     # 지정한 개수만큼 각 실험마다 임의의 집단 생성. Test 시에만 사용하며, ExperimentManager의 create_test_experiments와 함께 사용할 것.
-    def create_test_groups(self, num, ramp_up=False, ramp_up_percent=0.5):
+    def create_test_groups(self, num, ramp_up='no', ramp_up_percent=0.5,
+                           ramp_up_end_time=timezone.now()+timezone.timedelta(days=3.5)):
         from .models import Experiment
         for experiment in Experiment.objects.all(): # 모든 존재하는 실험에 대해
             self.create(name='0', weight=1, control=True, experiment=experiment) # 통제집단 1개 생성
             for i in range(num-1):
                 self.create(name=str(i+1), weight=1, control=False, ramp_up=ramp_up,
-                            ramp_up_percent=ramp_up_percent, experiment=experiment) # num-1개의 실험집단들 생성
+                            ramp_up_percent=ramp_up_percent, ramp_up_end_time=ramp_up_end_time,
+                            experiment=experiment) # num-1개의 실험집단들 생성
 
 class GoalManager(models.Manager):
 

--- a/templates/admin/experimenter/change_form.html
+++ b/templates/admin/experimenter/change_form.html
@@ -14,6 +14,7 @@
     var control = ".form-row.field-control";
     var ramp_up = ".form-row.field-ramp_up";
     var ramp_up_percent = ".form-row.field-ramp_up_percent";
+    var ramp_up_end_time = ".form-row.field-ramp_up_end_time";
     var goals = "#goal_set-group";
 
     // hide unnecessary elements
@@ -22,12 +23,17 @@
     $(groups).find(control).hide();
     $(groups).find(ramp_up).first().hide();
 
-    // function that shows or hides ramp_up_percent depending on value of ramp_up
+    // function that shows or hides ramp_up_percent and ramp_up_end_time depending on value of ramp_up
     function showhide_ramp_up_percent(_this) {
-        if ($(_this).find(":radio:checked").val() == 'True') {
+        if ($(_this).find(":radio:checked").val() == 'manual') {
             $(_this).parents(".module.aligned").find(ramp_up_percent).show();
         } else {
             $(_this).parents(".module.aligned").find(ramp_up_percent).hide();
+        }
+        if ($(_this).find(":radio:checked").val() == 'automatic') {
+            $(_this).parents(".module.aligned").find(ramp_up_end_time).show();
+        } else {
+            $(_this).parents(".module.aligned").find(ramp_up_end_time).hide();
         }
     };
 
@@ -38,6 +44,7 @@
             $(weight).hide();
             $(groups).find(ramp_up).slice(1).hide();
             $(ramp_up_percent).hide();
+            $(ramp_up_end_time).hide();
             } else {
             $(assignment_update_interval).hide();
             $(weight).show();
@@ -56,23 +63,19 @@
     // show or hide elements upon already assigned values
     $(document).ready(function(){
         $(goals).find("tr.add-row").hide();
-        if ($(algorithm).find("#id_algorithm option:selected").val() == 'bandit') {
-            $(assignment_update_interval).show();
-            $(weight).hide();
-            $(groups).find(ramp_up).slice(1).hide();
-            $(ramp_up_percent).hide();
-            };
-        if ($(algorithm).find("div.readonly").text() == 'Multi-armed Bandit') {
-            $(assignment_update_interval).show();
-            $(weight).hide();
-            $(groups).find(ramp_up).slice(1).hide();
-            $(ramp_up_percent).hide();
-            }
         $(groups).find(control).first().find("input:checkbox")
         .attr("checked", true);
         $(ramp_up).each(function(){
                 showhide_ramp_up_percent(this)
             });
+        if ($(algorithm).find("#id_algorithm option:selected").val() == 'bandit' ||
+        $(algorithm).find("div.readonly").text() == 'Multi-armed Bandit') {
+            $(assignment_update_interval).show();
+            $(weight).hide();
+            $(groups).find(ramp_up).slice(1).hide();
+            $(ramp_up_percent).hide();
+            $(ramp_up_end_time).hide();
+            };
     });
 
 


### PR DESCRIPTION
- Group 모델의 ramp_up 필드 변경(선택지가 dont use, manual, automatic의 세 가지로 바뀜)
- Group 모델에 ramp_up_end_time 필드 추가. 이 필드에 설정한 시간이 되면 실험 집단에 할당하는 비율이 100%가 되고 그 전까지 비율이 선형적으로 증가.